### PR TITLE
Create stub configuration.txt file

### DIFF
--- a/configuration.txt
+++ b/configuration.txt
@@ -1,0 +1,2 @@
+values.yaml
+values/oauth.yaml


### PR DESCRIPTION
Because it's required by the `helm upgrade --install` command from the docs, i.e. when you reach [this point](https://gitpod-staging.netlify.com/docs/self-hosted/latest/install/10_install_on_kubernetes/#installation) you'll get an error if you don't have that file.